### PR TITLE
Tabela em paisagem

### DIFF
--- a/app/views/tccs/generate.pdf.erb
+++ b/app/views/tccs/generate.pdf.erb
@@ -32,6 +32,9 @@ brazil,				% o último idioma é o principal do documento
 \usepackage{multirow}          % Tabelas com diferentes números de colunas
 \usepackage{tabulary,booktabs}
 \usepackage[english]{selnolig} % Permite desabilitar "ligatures"
+\usepackage{pdflscape}         % Tabela em landscape
+% \begin{landscape}
+% \end{landscape}
 
 % ---
 % Pacotes XeLatex

--- a/latex/xh2latex.xsl
+++ b/latex/xh2latex.xsl
@@ -332,6 +332,14 @@ http://www.csclub.uwaterloo.ca/u/sjbmann/tutorial.html
   </xsl:text>
 </xsl:template>
 
+<!-- landscape -->
+<xsl:template match="xhtml:landscape">
+  <xsl:text>\begin{landscape}</xsl:text>
+  <xsl:apply-templates />
+  <xsl:text>\end{landscape}</xsl:text>
+
+</xsl:template>
+
 <!-- tables -->
 <xsl:template match="xhtml:table">
   <xsl:text>\begin{table}</xsl:text>

--- a/lib/tcc_document/html_processor.rb
+++ b/lib/tcc_document/html_processor.rb
@@ -88,6 +88,23 @@ module TccDocument
         table.replace table.to_s.gsub('<ul>', '').gsub('</ul>', '').gsub('<li>', '').gsub('</li>', '')
       end
 
+      nokogiri_html.search('table').each do |table|
+        begin
+          Timeout::timeout(3) {
+            if (/<table\s*[^<>]*>/.match(table.to_s).to_s.include?('summary="landscape') ||
+                /<table\s*[^<>]*>/.match(table.to_s).to_s.include?('summary="paisagem')
+            )
+              table.replace table.to_s.gsub(/<table\s*[^<>]*>/, "<landscape>#{/<table\s*[^<>]*>/.match(table.to_s).to_s}").gsub('</table>', '</table></landscape>')
+
+            end
+          }
+        rescue Timeout::Error
+          #
+          puts("Timeout::Error => nokogiri_html.search('table') -> summary=\"paisagem")
+        end
+
+      end
+
       nokogiri_html
     end
 


### PR DESCRIPTION
Inclusão da palavra reservada landscape na geração do latex

No sumário da tabela deve iniciar dom a palavra reservada "landscape":
[summary="landscape]

proteção de fluxo de execução